### PR TITLE
Fix typography in names-of-type-members.md

### DIFF
--- a/docs/standard/design-guidelines/names-of-type-members.md
+++ b/docs/standard/design-guidelines/names-of-type-members.md
@@ -56,7 +56,7 @@ public class String {
   
  **✓ DO** name collection properties with a plural phrase describing the items in the collection instead of using a singular phrase followed by "List" or "Collection."  
   
- **✓ DO** name Boolean properties with an affirmative phrase (`CanSeek` instead of `CantSeek`). Optionally, you can also prefix Boolean properties with "Is," "Can," or "Has," but only where it adds value.  
+ **✓ DO** name Boolean properties with an affirmative phrase (`CanSeek` instead of `CantSeek`). Optionally, you can also prefix Boolean properties with "Is", "Can", or "Has", but only where it adds value.  
   
  **✓ CONSIDER** giving a property the same name as its type.  
   


### PR DESCRIPTION
In the section of boolean properties the comma was inside the quoted values of the prefix list.

## Summary

I corrected the list of prefix values as the comma was inside the quoted values.

`"Is," "Can," or "Has,"` => `"Is", "Can", or "Has",`